### PR TITLE
In facebook twig file changed sdk.js to all.js (see issue #9)

### DIFF
--- a/templates/plugins/jscomments/facebook.html.twig
+++ b/templates/plugins/jscomments/facebook.html.twig
@@ -16,7 +16,7 @@
       var js, fjs = d.getElementsByTagName(s)[0];
       if (d.getElementById(id)) return;
       js = d.createElement(s); js.id = id;
-      js.src = "//connect.facebook.net/{{ language|default('en_US')|e('js') }}/sdk.js#xfbml=1&amp;appId={{ app_id|e('js') }}&amp;version=v2.5";
+      js.src = "//connect.facebook.net/{{ language|default('en_US')|e('js') }}/all.js#xfbml=1&amp;appId={{ app_id|e('js') }}";
       fjs.parentNode.insertBefore(js, fjs);
     }(document, 'script', 'facebook-jssdk'));
   </script>


### PR DESCRIPTION
Changing this fixed it on my install. But the code in your original twig file does indeed match the code Facebook is generating for me (with the exception of version 2.5 -> 2.7). But changing the version number didn't fix the problem. I have no other Facebook widgets, so this was the only SDK being loaded.
