### PR TITLE
hypercomments template -> social -> array to string 

### DIFF
--- a/templates/plugins/jscomments/hypercomments.html.twig
+++ b/templates/plugins/jscomments/hypercomments.html.twig
@@ -13,7 +13,7 @@
         _hcwp.push({
             widget: "Stream",
             widget_id: '{{ widget_id|e('js') }}',
-            social: '{{ social|e('js') }}'
+            social: '{{ social|join(',') }}'
         });
         (function () {
             if ("HC_LOAD_INIT" in window) {


### PR DESCRIPTION
Update of the template of hypercomments to put the social array into a string in the plugin because it's mandatory from : https://www.hypercomments.com/en/documentation